### PR TITLE
UCBG-405: revisions to public portal fields, csv headers, grid view

### DIFF
--- a/botgarden/plantinfo.csv
+++ b/botgarden/plantinfo.csv
@@ -12,62 +12,61 @@ core	botgarden-public															x
 #		Fields						row,column								x
 #																x
 header		Name	Label	SolrField	SearchTarget	Suggestions	Role	Search	Facet	bMapper	fullDisplay	listDisplay	gridDisplay	mapDisplay	inCSV	placeholder
-field	1	id	id	id			id									x
-field	2	csid	CSID	csid_s			csid									x
-field	3	accessionnumber	Accession Number	accessionnumber_s		ob	objectno,accession,string,sortkey	8,3		1		1	1		1	x
-field	4	determination	Scientific Name	determination_s		ta	keyword,mainentry	1,1		2		2	2		2	x
-field	5	collector	Collector	collector_s		pe	keyword	5,1	1			3	3		3	x
-field	6	collectornumber	Collector Number	collectornumber_s			keyword	6,1	2		2	4	4		4	x
-field	7	collectiondate	Collection Date	collectiondate_s			keyword	7,1			3				5	x
-field	8	earlycollectiondate	Early Collection Date	earlycollectiondate_s			keyword				4					x
-field	9	latecollectiondate	Late Collection Date	latecollectiondate_s			keyword									x
-field	10	fcpverbatim	Field Place Name	fcpverbatim_s			keyword	6,2			5				6	x
-field	11	collcounty	County	collcounty_ss			dropdown	8,1	3		6				7	x
-field	12	collstate	State	collstate_ss			dropdown	9,1	4		7				8	x
-field	13	collcountry	Country	collcountry_ss			dropdown	10,1	5		8	5	5		9	x
-field	14	elevation	Elevation	elevation_s			keyword	1,2			9				10	x
-field	15	minelevation	Min elevation	minelevation_s			keyword									x
-field	16	maxelevation	Max elevation	maxelevation_s			keyword									x
-field	17	elevationunit	Elevation unit	elevationunit_s			keyword									x
-field	18	habitat	Habitat	habitat_s			keyword	2,2			10				11	x
-field	19	latlong	LatLong	latlong_p			location				37				38	x
-field	20	trscoordinates	TRS coordinates	trscoordinates_s			keyword							1		x
-field	21	datum	Datum	datum_s			dropdown							2		x
-field	22	coordinatesource	Coordinate source	coordinatesource_s			keyword							3		x
-field	23	coordinateuncertainty	Coordinate uncertainty	coordinateuncertainty_s			keyword							4		x
-field	24	coordinateuncertaintyunit	Coordinate uncertainty unit	coordinateuncertaintyunit_s			keyword							5		x
-field	25	family	Family	family_s			dropdown	3,1	6		11	6			12	x
-field	26	gardenlocation	Garden Location	gardenlocation_s			keyword	4,2	7		12	7	6		13	x
-field	27	dataquality	Data Quality	dataquality_s			keyword				13					x
-field	28	locality	Geographic Place Name	locality_s		pl	keyword	5,2			14				14	x
-field	29	rare	Rare?	rare_s			dropdown	2,3	8		15	8	7		15	x
-field	30	deadflag	Dead?	deadflag_s			dropdown	1,3	9		16	9	8		16	x
-field	31	flowercolor	Flower Color	flowercolor_s			keyword	3,3	10		17	10	9		17	x
-field	32	determinationnoauth	Determination	determinationnoauth_s			keyword				18				18	x
-field	33	reasonformove	Reason for Move	reasonformove_s			keyword				19				19	x
-field	34	conservationinfo	Conservation Information	conservationinfo_ss			keyword				23				21	x
-field	35	conserveorg	Conservation Organization	conserveorg_ss			dropdown	7,2								x
-field	36	conservecat	Conservation Category	conservecat_ss			dropdown	8,2								x
-field	37	voucherlist	Vouchers	voucherlist_ss			keyword	7,3			21				22	x
-field	38	vouchers	Has Vouchers	vouchers_s			dropdown	6,3			20				20	x
-field	39	vouchercount	Voucher Count	vouchercount_s			keyword									x
-field	40	keyword	Keyword	text			keyword	3,2								x
-field	40	fruitingverbatim	Fruiting (verbatim)	fruitingverbatim_ss			colors= {"f":"lightgray","t":"orange"}				25				25	x
+field	1	id	id	id			id					
+field	2	csid	CSID	csid_s			csid					
+field	3	accessionnumber	Accession Number	accessionnumber_s		ob	objectno,accession,string,sortkey	7,3		1		1
+field	4	determination	Scientific Name	determination_s		ta	keyword,mainentry	1,1		2		2
+field	5	collector	Collector	collector_s		pe	keyword	1,2	1			3
+field	6	collectornumber	Collector Number	collectornumber_s			keyword	2,2	2		2	4
+field	7	collectiondate	Collection Date	collectiondate_s			keyword	3,2			3	
+field	8	earlycollectiondate	Early Collection Date	earlycollectiondate_s			keyword				4	
+field	9	latecollectiondate	Late Collection Date	latecollectiondate_s			keyword					
+field	10	fcpverbatim	Field Place Name	fcpverbatim_s			keyword	7,2			5	
+field	11	collcounty	County	collcounty_ss			dropdown	5,1	3		6	
+field	12	collstate	State	collstate_ss			dropdown	6,1	4		7	
+field	13	collcountry	Country	collcountry_ss			dropdown	7,1	5		8	5
+field	14	elevation	Elevation	elevation_s			keyword				9	
+field	15	minelevation	Min elevation	minelevation_s			keyword					
+field	16	maxelevation	Max elevation	maxelevation_s			keyword					
+field	17	elevationunit	Elevation unit	elevationunit_s			keyword					
+field	18	habitat	Habitat	habitat_s			keyword				10	
+field	19	latlong	LatLong	latlong_p			location				37	
+field	20	trscoordinates	TRS coordinates	trscoordinates_s			keyword					
+field	21	datum	Datum	datum_s			dropdown					
+field	22	coordinatesource	Coordinate source	coordinatesource_s			keyword					
+field	23	coordinateuncertainty	Coordinate uncertainty	coordinateuncertainty_s			keyword					
+field	24	coordinateuncertaintyunit	Coordinate uncertainty unit	coordinateuncertaintyunit_s			keyword					
+field	25	family	Family	family_s			dropdown	3,1	6		11	6
+field	26	gardenlocation	Garden Location	gardenlocation_s			keyword	5,2	7		12	7
+field	27	dataquality	Data Quality	dataquality_s			keyword				13	
+field	28	locality	Geographic Place Name	locality_s		pl	keyword	6,2			14	
+field	29	rare	Rare?	rare_s			dropdown	1,3	8		15	8
+field	30	deadflag	Dead?	deadflag_s			dropdown	8,1	9		16	9
+field	31	flowercolor	Flower Color	flowercolor_s			keyword	2,3	10		17	10
+field	32	determinationnoauth	Determination	determinationnoauth_s			keyword				18	
+field	33	reasonformove	Reason for Move	reasonformove_s			keyword				19	
+field	34	conservationinfo	Conservation Information	conservationinfo_ss			keyword				23	
+field	35	conserveorg	Conservation Organization	conserveorg_ss			dropdown	8,2				
+field	36	conservecat	Conservation Category	conservecat_ss			dropdown	9,2				
+field	37	voucherlist	Vouchers	voucherlist_ss			keyword	6,3			21	
+field	38	vouchers	Has Vouchers	vouchers_s			dropdown	5,3			20	
+field	39	vouchercount	Voucher Count	vouchercount_s			keyword					
+field	40	keyword	Keyword	text			keyword	4,2				
+field	40	fruitingverbatim	Fruiting (verbatim)	fruitingverbatim_ss			colors= {"f":"lightgray","t":"orange"}				25				22	x
 field	41	floweringverbatim	Flowering (verbatim)	floweringverbatim_ss			colors= {"No":"lightgray","Some":"pink","Many":"red"}				24				23	x
 field	42	provenancetype	Provenance Type	provenancetype_s			keyword				22				24	x
-field	43	fruiting	Fruiting (months)	fruiting_ss			keyword	5,3								x
-field	44	flowering	Flowering (months)	flowering_ss			keyword	4,3								x
-field	45	authorsParsed	Authors (parsed)	authorsParsed_s			keyword				26				26	x
-field	46	authorship	Authorship	authorship_s			keyword				27				27	x
-field	47	bracketAuthorship	Bracket Authorship	bracketAuthorship_s			keyword				28				28	x
-field	48	canonicalName	Canonical Name	canonicalName_s			keyword				29				29	x
-field	49	canonicalNameComplete	Canonical Name Complete	canonicalNameComplete_s			keyword				30				30	x
-field	50	canonicalNameWithMarker	Canonical Name With Marker	canonicalNameWithMarker_s			keyword				31				31	x
-field	51	genusOrAbove	Genus or above	genusOrAbove_s			keyword	4,1			32				32	x
-field	52	infraSpecificEpithet	Infraspecific Epithet	infraSpecificEpithet_s			keyword				33				33	x
-field	53	rankMarker	Rank Marker	rankMarker_s			keyword				34				34	x
-field	54	scientificName	Scientific Name	scientificName_s			keyword				35				35	x
-field	55	specificEpithet	Specific Epithet	specificEpithet_s			keyword				36				36	x
-field	56	type	Type	type_s			dropdown				38				37	x
-field	57	commonname	Common Name	commonname_s			keyword	2,1			1				39	x
-field	58	blobs	Images	blob_ss			blob									x
+field	43	fruiting	Fruiting (months)	fruiting_ss			keyword	4,3								x
+field	44	flowering	Flowering (months)	flowering_ss			keyword	3,3								x
+field	45	authorsParsed	Authors (parsed)	authorsParsed_s			keyword				26					x
+field	46	authorship	Authorship	authorship_s			keyword				27					x
+field	47	bracketAuthorship	Bracket Authorship	bracketAuthorship_s			keyword				28					x
+field	48	canonicalName	Canonical Name	canonicalName_s			keyword				29					x
+field	49	canonicalNameComplete	Canonical Name Complete	canonicalNameComplete_s			keyword				30					x
+field	50	canonicalNameWithMarker	Canonical Name With Marker	canonicalNameWithMarker_s			keyword				31				25	x
+field	51	genusOrAbove	Genus or above	genusOrAbove_s			keyword	4,1			32				26	x
+field	52	infraSpecificEpithet	Infraspecific Epithet	infraSpecificEpithet_s			keyword				33				28	x
+field	53	rankMarker	Rank Marker	rankMarker_s			keyword				34				29	x
+field	54	scientificName	Scientific Name	scientificName_s			keyword				35					x
+field	55	specificEpithet	Specific Epithet	specificEpithet_s			keyword				36				27	x
+field	56	type	Type	type_s			dropdown				38					x
+field	57	commonname	Common Name	commonname_s			keyword	2,1			1				30	x


### PR DESCRIPTION
Includes:

1. public search form:
     -   removed Elevation & Habitat in column 2 from public
     -   moved Collector, Collector Number, Collection Date to the top of 2nd column
     -   moved "Dead?" to bottom of 1st column
2. csv headers:
     -   removed columns: S, T, AA, AB, AC, AD, AE, AJ, AL
     -   had genusOrAbove and specificEpithet columns next to each other
3. grid view
     -   included family to reflect fields in List view
     -   removed 2nd scientific name (previously duplicated under picture and in list of fields)
